### PR TITLE
Fix Haiku POSIX port using generic kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -734,6 +734,15 @@ get-config-for-kset = $(lastword $(subst :, ,$(filter $(1):%,$(KCONFIG_MAP))))
 # for that sub-configuration.
 $(foreach conf, $(CONFIG_LIST), $(eval $(call make-config-rule,$(conf))))
 
+# Also, instantiate the rule for CONFIG_NAME itself, if it's not in CONFIG_LIST
+# and corresponds to an actual directory with source files.
+# This handles cases like 'haiku' which is a family name but also has its own config file.
+ifneq ($(filter $(CONFIG_NAME),$(CONFIG_LIST)),$(CONFIG_NAME))
+ifneq ($(wildcard $(CONFIG_PATH)/$(CONFIG_NAME)/.),)
+$(eval $(call make-config-rule,$(CONFIG_NAME)))
+endif
+endif
+
 # Instantiate the build rule for framework files. Use the CFLAGS for the
 # configuration family, which exists in the directory whose name is equal to
 # CONFIG_NAME. Note that this doesn't need to be in a loop since we expect

--- a/config/haiku/bli_cntx_init_haiku.c
+++ b/config/haiku/bli_cntx_init_haiku.c
@@ -1,0 +1,46 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2014, The University of Texas at Austin
+   Copyright (C) 2024, The BLIS Developers
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#include "blis.h"
+
+void bli_cntx_init_haiku( cntx_t* cntx )
+{
+	// Set default kernel blocksizes and functions.
+	// Since Haiku is initially aliasing generic, we call the generic_ref
+	// context initialization function. If Haiku were to have its own
+	// optimized kernels later, it would call its own _ref function.
+	bli_cntx_init_generic_ref( cntx );
+
+}

--- a/config/haiku/bli_kernel_defs_haiku.h
+++ b/config/haiku/bli_kernel_defs_haiku.h
@@ -1,0 +1,43 @@
+/*
+
+   BLIS
+   An object-based framework for developing high-performance BLAS-like
+   libraries.
+
+   Copyright (C) 2024, The BLIS Developers
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are
+   met:
+    - Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    - Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    - Neither the name(s) of the copyright holder(s) nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+   HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+   SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+   LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+#ifndef BLIS_KERNEL_DEFS_HAIKU_H
+#define BLIS_KERNEL_DEFS_HAIKU_H
+
+
+// -- REGISTER BLOCK SIZES (FOR REFERENCE KERNELS) ----------------------------
+
+// -- KERNEL IMPLEMENTATION ROUTINE PROTOTYPES ---------------------------------
+
+#endif

--- a/config/haiku/make_defs.mk
+++ b/config/haiku/make_defs.mk
@@ -1,0 +1,97 @@
+#
+#
+#  BLIS
+#  An object-based framework for developing high-performance BLAS-like
+#  libraries.
+#
+#  Copyright (C) 2014, The University of Texas at Austin
+#  Copyright (C) 2024, The BLIS Developers
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are
+#  met:
+#   - Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#   - Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   - Neither the name(s) of the copyright holder(s) nor the names of its
+#     contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+
+# Declare the name of the current configuration and add it to the
+# running list of configurations included by common.mk.
+THIS_CONFIG    := haiku
+#CONFIGS_INCL   += $(THIS_CONFIG)
+
+#
+# --- Determine the C compiler and related flags ---
+#
+
+# NOTE: The build system will append these variables with various
+# general-purpose/configuration-agnostic flags in common.mk. You
+# may specify additional flags here as needed.
+CPPROCFLAGS    := -D_POSIX_C_SOURCE=200809L
+CMISCFLAGS     :=
+CPICFLAGS      := -fPIC
+CWARNFLAGS     := -Wall
+
+ifneq ($(DEBUG_TYPE),off)
+CDBGFLAGS      := -g
+endif
+
+ifeq ($(DEBUG_TYPE),noopt)
+COPTFLAGS      := -O0
+else
+COPTFLAGS      := -O2
+endif
+
+# Flags specific to optimized kernels.
+CKOPTFLAGS     := $(COPTFLAGS) -O3
+ifeq ($(CC_VENDOR),gcc)
+CKVECFLAGS     :=
+else
+ifeq ($(CC_VENDOR),icc)
+CKVECFLAGS     :=
+else
+ifeq ($(CC_VENDOR),clang)
+CKVECFLAGS     :=
+else
+ifeq ($(CC_VENDOR),nvc)
+CKVECFLAGS     :=
+else
+$(error gcc, icc, nvc, or clang is required for this configuration.)
+endif
+endif
+endif
+endif
+
+# Flags specific to reference kernels.
+CROPTFLAGS     := $(CKOPTFLAGS)
+ifeq ($(CC_VENDOR),gcc)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+ifeq ($(CC_VENDOR),clang)
+CRVECFLAGS     := $(CKVECFLAGS) -funsafe-math-optimizations -ffp-contract=fast
+else
+CRVECFLAGS     := $(CKVECFLAGS)
+endif
+endif
+
+# Store all of the variables here to new variables containing the
+# configuration name.
+$(eval $(call store-make-defs,$(THIS_CONFIG)))

--- a/config_registry
+++ b/config_registry
@@ -67,3 +67,4 @@ sifive_x280: sifive_x280/sifive_rvv
 
 # Generic architectures.
 generic:     generic
+haiku:       generic

--- a/frame/base/bli_arch.c
+++ b/frame/base/bli_arch.c
@@ -326,6 +326,13 @@ arch_t bli_arch_query_id_impl( void )
 		#ifdef BLIS_FAMILY_GENERIC
 		id = BLIS_ARCH_GENERIC;
 		#endif
+
+		// Haiku configuration should default to generic architecture.
+		// This ensures 'id' is set if no other BLIS_FAMILY_XYZ matched,
+		// and BLIS_FAMILY_HAIKU is defined (which implies generic).
+		#ifdef BLIS_FAMILY_HAIKU
+		id = BLIS_ARCH_GENERIC;
+		#endif
 	}
 
 	if ( bli_arch_get_logging() )

--- a/frame/base/bli_gks.c
+++ b/frame/base/bli_gks.c
@@ -69,11 +69,19 @@ int bli_gks_init( void )
 	// bli_config.h.
 
 	#undef GENTCONF
-	#define GENTCONF( CONFIG, config ) \
-	\
-	bli_gks_register_cntx( PASTECH(BLIS_ARCH_,CONFIG), \
-	                       PASTEMAC(cntx_init_,config), \
-	                       PASTEMAC(cntx_init_,config,_ref) );
+	#ifdef BLIS_FAMILY_HAIKU
+	  // For Haiku, explicitly use GENERIC architecture for registration
+	  #define GENTCONF( CONFIG, config ) \
+	  bli_gks_register_cntx( BLIS_ARCH_GENERIC, \
+	                         PASTEMAC(cntx_init_,generic), \
+	                         PASTEMAC(cntx_init_,generic,_ref) );
+	#else
+	  // Original definition
+	  #define GENTCONF( CONFIG, config ) \
+	  bli_gks_register_cntx( PASTECH(BLIS_ARCH_,CONFIG), \
+	                         PASTEMAC(cntx_init_,config), \
+	                         PASTEMAC(cntx_init_,config,_ref) );
+	#endif
 
 	INSERT_GENTCONF
 


### PR DESCRIPTION
- Ensure bli_arch_query_id() returns BLIS_ARCH_GENERIC for Haiku.
- Ensure GKS registration uses BLIS_ARCH_GENERIC for Haiku.
- Add workaround for anomalous BLIS_INVALID_ARCH_ID error during GKS init specific to bli_gks.c, potentially due to compiler/environment issues.

With these changes, the library builds and passes 'make check' for the Haiku configuration.